### PR TITLE
feat: add fetch_translations_on_boot config option

### DIFF
--- a/lib/phrase/ota/backend.rb
+++ b/lib/phrase/ota/backend.rb
@@ -22,6 +22,10 @@ module Phrase
 
       def start_polling
         Thread.new do
+          if Phrase::Ota.config.fetch_translations_on_boot
+            update_translations
+          end
+
           loop do
             sleep(Phrase::Ota.config.poll_interval)
             update_translations

--- a/lib/phrase/ota/configuration.rb
+++ b/lib/phrase/ota/configuration.rb
@@ -14,6 +14,7 @@ module Phrase
       attr_accessor :available_locales
       attr_accessor :debug
       attr_accessor :yaml_permitted_classes
+      attr_accessor :fetch_translations_on_boot
       attr_writer :base_url
 
       def initialize
@@ -27,6 +28,7 @@ module Phrase
         @base_url = nil
         @debug = false
         @yaml_permitted_classes = []
+        @fetch_translations_on_boot = false
       end
 
       def base_url


### PR DESCRIPTION
## Issues related

Fixes: [KNOK-5769]

## Description

- Add `fetch_translations_on_boot` config option to allow the initial fetch of the translations (right now, we need to wait for the initial pool sleep and only then we fetch the first time - so, if we have a pool interval of one hour, we only have the translations on start after the first hour)




[KNOK-5769]: https://knokcare.atlassian.net/browse/KNOK-5769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ