### PR TITLE
feat: invert sleep fetch translations order on thread loop

### DIFF
--- a/lib/phrase/ota/backend.rb
+++ b/lib/phrase/ota/backend.rb
@@ -23,8 +23,8 @@ module Phrase
       def start_polling
         Thread.new do
           loop do
-            sleep(Phrase::Ota.config.poll_interval)
             update_translations
+            sleep(Phrase::Ota.config.poll_interval)
           end
         end
       end


### PR DESCRIPTION
## Issues related

Fixes: [KNOK-5769]


## Description

- Invert sleep and fetch translations operations order on thread loop so we perform the first fetch of the translation when booting the app

## Related PR's

- https://github.com/knok-healthcare/phrase-ota-i18n/pull/1


[KNOK-5769]: https://knokcare.atlassian.net/browse/KNOK-5769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ