### PR TITLE
Force TLS 1.2 for Phrase connections

### DIFF
--- a/lib/phrase/ota/backend.rb
+++ b/lib/phrase/ota/backend.rb
@@ -41,7 +41,7 @@ module Phrase
           current_version = @current_locale_versions[locale_cache_key(locale)]
           params[:current_version] = current_version unless current_version.nil?
 
-          connection = Faraday.new do |faraday|
+          connection = Faraday.new(ssl: { max_version: OpenSSL::SSL::TLS1_2_VERSION }) do |faraday|
             faraday.response :follow_redirects
             faraday.adapter Faraday.default_adapter
           end

--- a/lib/phrase/ota/backend.rb
+++ b/lib/phrase/ota/backend.rb
@@ -41,7 +41,7 @@ module Phrase
           current_version = @current_locale_versions[locale_cache_key(locale)]
           params[:current_version] = current_version unless current_version.nil?
 
-          connection = Faraday.new(ssl: { max_version: OpenSSL::SSL::TLS1_2_VERSION }) do |faraday|
+          connection = Faraday.new(ssl: { min_version: OpenSSL::SSL::TLS1_2_VERSION }) do |faraday|
             faraday.response :follow_redirects
             faraday.adapter Faraday.default_adapter
           end


### PR DESCRIPTION
Related this slack thread on the `eng-devops-sync` channel:

- https://knokteam.slack.com/archives/C088PEDUDP1/p1770631123615779

- Phrase OTA server (ota.eu.phrase.com) does not support TLS 1.3
  - Set `min_version: TLS1_2_VERSION` on the Faraday connection to force TLS 1.2 to be used